### PR TITLE
First attempts to make an ios library with zenroom

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -110,6 +110,52 @@ osx: platform := macosx
 osx: patches lua53 luazen milagro
 	CC=${gcc} CFLAGS="${cflags}" make -C src shared
 
+ios-armv7: ARCH := armv7
+ios-armv7: OS := iphoneos
+ios-armv7: gcc := $(shell xcrun --sdk iphoneos -f gcc)
+ios-armv7: ar := $(shell xcrun --sdk iphoneos -f ar)
+ios-armv7: ld := $(shell xcrun --sdk iphoneos -f ld)
+ios-armv7: ranlib := $(shell xcrun --sdk iphoneos -f ranlib)
+ios-armv7: SDK := $(shell xcrun --sdk iphoneos --show-sdk-path)
+ios-armv7: cflags := -O2 -fPIC ${cflags_protection} -D'ARCH=\"OSX\"' -isysroot ${SDK} -arch ${ARCH} -D NO_SYSTEM
+ios-armv7: ldflags := -lm
+ios-armv7: platform := ios
+ios-armv7: patches lua53 luazen milagro
+	CC=${gcc} CFLAGS="${cflags}" make -C src library
+	${AR} rcs zenroom-armv7.a `find . -name \*.o`
+
+ios-arm64: ARCH := arm64
+ios-arm64: OS := iphoneos
+ios-arm64: gcc := $(shell xcrun --sdk iphoneos -f gcc)
+ios-arm64: ar := $(shell xcrun --sdk iphoneos -f ar)
+ios-arm64: ld := $(shell xcrun --sdk iphoneos -f ld)
+ios-arm64: ranlib := $(shell xcrun --sdk iphoneos -f ranlib)
+ios-arm64: SDK := $(shell xcrun --sdk iphoneos --show-sdk-path)
+ios-arm64: cflags := -O2 -fPIC ${cflags_protection} -D'ARCH=\"OSX\"' -isysroot ${SDK} -arch ${ARCH} -D NO_SYSTEM
+ios-arm64: ldflags := -lm
+ios-arm64: platform := ios
+ios-arm64: patches lua53 luazen milagro
+	CC=${gcc} CFLAGS="${cflags}" make -C src library
+	${AR} rcs zenroom-arm64.a `find . -name \*.o`
+
+ios-sim: ARCH := x86_64
+ios-sim: OS := iphonesimulator
+ios-sim: gcc := $(shell xcrun --sdk iphonesimulator -f gcc)
+ios-sim: ar := $(shell xcrun --sdk iphonesimulator -f ar)
+ios-sim: ld := $(shell xcrun --sdk iphonesimulator -f ld)
+ios-sim: ranlib := $(shell xcrun --sdk iphonesimulator -f ranlib)
+ios-sim: SDK := $(shell xcrun --sdk iphonesimulator --show-sdk-path)
+ios-sim: cflags := -O2 -fPIC ${cflags_protection} -D'ARCH=\"OSX\"' -isysroot ${SDK} -arch ${ARCH} -D NO_SYSTEM
+ios-sim: ldflags := -lm
+ios-sim: platform := ios
+ios-sim: patches lua53 luazen milagro
+	CC=${gcc} CFLAGS="${cflags}" make -C src library
+	${AR} rcs zenroom-x86_64.a `find . -name \*.o`
+
+
+ios-fat:
+	lipo -create zenroom-x86_64.a zenroom-arm64.a zenroom-armv7.a -output zenroom.a
+
 debug: gcc := gcc
 debug: cflags := -O0 -ggdb -D'ARCH=\"LINUX\"'
 debug: patches lua53 luazen milagro

--- a/build-ios.sh
+++ b/build-ios.sh
@@ -1,0 +1,9 @@
+rm -f *.a
+make clean
+make ios-sim
+make clean
+make ios-armv7
+make clean
+make ios-arm64
+
+make ios-fat

--- a/lib/lua53/src/Makefile
+++ b/lib/lua53/src/Makefile
@@ -112,6 +112,9 @@ linux:
 macosx:
 	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX" SYSLIBS="-lreadline" CC=cc
 
+ios:
+	$(MAKE) $(ALL) SYSCFLAGS="-DLUA_USE_MACOSX" SYSLIBS="-lreadline"
+
 mingw:
 	$(MAKE) "LUA_A=lua53.dll" "LUA_T=lua.exe" \
 	"AR=$(CC) -shared -o" "RANLIB=strip --strip-unneeded" \

--- a/lib/lua53/src/loslib.c
+++ b/lib/lua53/src/loslib.c
@@ -140,6 +140,8 @@ static time_t l_checktime (lua_State *L, int arg) {
 
 static int os_execute (lua_State *L) {
   const char *cmd = luaL_optstring(L, 1, NULL);
+
+#ifndef NO_SYSTEM
   int stat = system(cmd);
   if (cmd != NULL)
     return luaL_execresult(L, stat);
@@ -147,6 +149,9 @@ static int os_execute (lua_State *L) {
     lua_pushboolean(L, stat);  /* true if there is a shell */
     return 1;
   }
+#else
+  return 1;
+#endif
 }
 
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -74,6 +74,8 @@ win: ${SOURCES}
 	${CC} ${CFLAGS} ${LDFLAGS} -o zenroom.exe zenroom.res ${SOURCES} ${LDADD}
 	x86_64-w64-mingw32-strip zenroom.exe
 
+library: CFLAGS += -D LIBRARY
+library: ${SOURCES}
 
 debug: CFLAGS+= -ggdb -DDEBUG=1 -Wall
 debug: LDADD+= -lm

--- a/src/zenroom.c
+++ b/src/zenroom.c
@@ -180,6 +180,7 @@ int zenroom_exec(char *script, char *conf, char *keys,
 	return(return_code);
 }
 
+#ifndef LIBRARY
 int main(int argc, char **argv) {
 	char conffile[MAX_STRING];
 	char scriptfile[MAX_STRING];
@@ -294,3 +295,4 @@ int main(int argc, char **argv) {
 	// exit(1) on failure
 	exit(ret);
 }
+#endif

--- a/src/zenroom.h
+++ b/src/zenroom.h
@@ -17,6 +17,9 @@
  #endif
 #endif
 
+int zenroom_exec(char *script, char *conf, char *keys,
+                 char *data, int verbosity);
+
 #define ERROR() error("Error in %s",__func__)
 #define SAFE(x) if(!x){error("NULL variable in %s",__func__);return 0;}
 #define FREE(p) if(p){func("free(%p)",p); free(p);}


### PR DESCRIPTION
1. on iOS you can not call to system() syscall so I added a #ifndef to prevent this line to be on the lua code

2. A library cannot have a main(int argc, char **argv) so again I added a #ifndef 

3. The build-ios.sh creates three architectures armv7 (old devices) arm64 (64 bits devices) and x86_64 (simulator) and then creates a fat file with the three combined
