### PR TITLE
linux shared lib targets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,12 @@ shared: platform := linux
 shared: patches lua53 milagro
 	CC=${gcc} CFLAGS="${cflags}" make -C src shared
 
+shared-lib: gcc := gcc
+shared-lib: cflags := -O2 -fPIC ${cflags_protection} -D'ARCH=\"LINUX\"' -shared
+shared-lib: ldflags := -lm
+shared-lib: platform := linux
+shared-lib: patches lua53 milagro
+	CC=${gcc} CFLAGS="${cflags}" make -C src shared-lib
 
 osx: gcc := gcc
 osx: cflags := -O2 -fPIC ${cflags_protection} -D'ARCH=\"OSX\"'

--- a/src/Makefile
+++ b/src/Makefile
@@ -19,6 +19,8 @@
 CC?=gcc
 VERSION := $(shell cat ../VERSION)
 ARCH := $(shell uname -m)
+BRANCH := $(shell git symbolic-ref HEAD | sed -e 's,.*/\(.*\),\1,')
+HASH := $(shell git rev-parse --short HEAD)
 CFLAGS  += -I. -I../lib/lua53/src -I../lib/milagro-crypto-c/include -Wall -Wextra
 SOURCES := \
 	jutils.o zenroom.o zen_error.o \
@@ -72,6 +74,10 @@ shared: LDADD+=   -lm -lpthread
 shared: ${SOURCES}
 	${CC} ${CFLAGS} ${SOURCES} -o zenroom-shared ${LDFLAGS} ${LDADD}
 
+shared-lib: LDADD+=   -lm
+shared-lib: ${SOURCES}
+	${CC} ${CFLAGS} ${SOURCES} -o libzenroom-${ARCH}-${VERSION}-${BRANCH}-${HASH}.so ${LDFLAGS} ${LDADD}
+
 win: CFLAGS +=  -O3 -Wall -Wextra -pedantic -std=gnu99
 win: LDFLAGS += -L/usr/x86_64-w64-mingw32/lib -static
 win: LDADD +=  -l:libm.a -l:libpthread.a -lssp
@@ -94,6 +100,7 @@ debug: clean ${SOURCES}
 
 clean:
 	rm -f *.o
+	rm -f *.so
 	rm -f zenroom-static
 	rm -f zenroom-shared
 	rm -f zenroom.js


### PR DESCRIPTION
I have been using these targets in the makefile to get a shared library in linux, it adds a pedantic way to tag the library ( ARCH VERSION BRANCH and GIT HASH  ) to track zenroom changes, but it is being pointed by a symlin called `libzenroom.so` in our machines.
I would like to know if this is ok to be merge or you think it needs some refinement.
