### PR TITLE
ADD support for react-native

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,14 +46,29 @@ apply-patches:
 
 # TODO: improve flags according to
 # https://github.com/kripken/emscripten/blob/master/src/settings.js
-javascript-node: cflags += -DARCH_JS -D'ARCH=\"JS\"' --memory-init-file 1
-javascript-node: ldflags += --memory-init-file 1
+Javascript-node: cflags += -DARCH_JS -D'ARCH=\"JS\"' --memory-init-file 1
+javascript-node: ldflags += --memory-init-file 1 -s WASM=0
 javascript-node: apply-patches lua53 milagro lpeglabel
 	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
 	make -C src js
 	@mkdir -p build/nodejs
 	@cp -v src/zenroom.js 	  build/nodejs/
 	@cp -v src/zenroom.js.mem build/nodejs/
+
+
+javascript-rn: cflags += -DARCH_JS -D'ARCH=\"JS\"' --memory-init-file 0
+javascript-rn: ldflags += -s WASM=0 --memory-init-file 0 -s MEM_INIT_METHOD=0 -s ASSERTIONS=1 -s NO_EXIT_RUNTIME=0 -s LEGACY_VM_SUPPORT=1 -s MODULARIZE=1
+javascript-rn: apply-patches lua53 milagro lpeglabel
+	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
+	make -C src js
+	@mkdir -p build/rnjs
+	sed -i 's/require("crypto")/require(".\/crypto")/g' src/zenroom.js
+	sed -i 's/require("[^\.]/console.log("/g' src/zenroom.js
+	sed -i 's/;ENVIRONMENT_IS_SHELL=[^;]*;/;ENVIRONMENT_IS_SHELL=true;/g' src/zenroom.js
+	sed -i 's/;ENVIRONMENT_IS_NODE=[^;]*;/;ENVIRONMENT_IS_NODE=false;/g' src/zenroom.js
+	sed -i 's/;ENVIRONMENT_IS_WORKER=[^;]*;/;ENVIRONMENT_IS_WORKER=false;/g' src/zenroom.js
+	sed -i 's/;ENVIRONMENT_IS_WEB=[^;]*;/;ENVIRONMENT_IS_WEB=false;/g' src/zenroom.js
+	@cp -v src/zenroom.js 	  build/rnjs/
 
 javascript-wasm: cflags += -DARCH_WASM -D'ARCH=\"WASM\"'
 javascript-wasm: ldflags += -s WASM=1 -s MODULARIZE=1

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ apply-patches:
 
 # TODO: improve flags according to
 # https://github.com/kripken/emscripten/blob/master/src/settings.js
-Javascript-node: cflags += -DARCH_JS -D'ARCH=\"JS\"' --memory-init-file 1
+javascript-node: cflags += -DARCH_JS -D'ARCH=\"JS\"' --memory-init-file 1
 javascript-node: ldflags += --memory-init-file 1 -s WASM=0
 javascript-node: apply-patches lua53 milagro lpeglabel
 	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \


### PR DESCRIPTION
Also fix non generating the `zenroom.js.mem` on newer emscripten sdk.

For make it work with react-native you also need to provide `crypto.js` file in the same folder and install buffer on the react-native app `npm install buffer`

```

var Buffer = require('buffer/').Buffer

const getRandomValues = (byteArray) => {
    for (let i = 0; i < byteArray.length; i++) {
        byteArray[i] = Math.floor(256 * Math.random());
    }
}
const randomBytes = (size, cb) => {
    if (size > 65536) throw new Error('requested too many random bytes')
    var rawBytes = new global.Uint8Array(size)

    // This will not work in older browsers.
    // See https://developer.mozilla.org/en-US/docs/Web/API/window.crypto.getRandomValues
    if (size > 0) {  // getRandomValues fails on IE if size == 0
        getRandomValues(rawBytes)
    }
    var bytes = Buffer.from(rawBytes.buffer)

    if (cb) {
        cb(bytes);
    }
    return bytes
}
module.exports = { randomBytes };
```
