### PR TITLE
[+Jordi] Added ldadd flag for musl-system target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ musl-local: apply-patches lua53 milagro lpeglabel
 		make -C src musl
 
 musl-system: gcc := gcc
+musl-system: ldadd += -lm
 musl-system: apply-patches lua53 milagro lpeglabel
 	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
 		make -C src musl


### PR DESCRIPTION
We needed to add the math library to compile 🔢 

We only added it for the `musl-system` target, maybe it's needed for other targets as well?