### PR TITLE
Tidy up javascript build targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@ docs/test
 docs/pub
 docs/fonts
 lib/musl
+src/zenroom.js
 src/zenroom.wasm
 src/zenroom-shared
 build/Zenroom-*
@@ -29,6 +30,7 @@ build/python3
 build/*go
 build/*java
 build/*x86
+build/*npm
 # generated files by milagro
 lib/milagro-crypto-c/AMCLConfig.cmake
 lib/milagro-crypto-c/AMCLConfigVersion.cmake

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ docs/pub
 docs/fonts
 lib/musl
 src/zenroom.js
+src/zenroom.js.mem
 src/zenroom.wasm
 src/zenroom-shared
 build/Zenroom-*

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test-exec := ${pwd}/src/zenroom-shared -c ${pwd}/test/decode-test.conf
 
 all:
 	@echo "Choose a target:"
-	@echo "- javascript-node, javascript-wasm, javascript-demo (need EMSDK env)"
+	@echo "- javascript-asmjs, javascript-npm, javascript-rn, javascript-demo (need EMSDK env)"
 	@echo "- linux, linux-lib, linux-clang, linux-debug"
 	@echo "- linux-python, linux-java        (language bindings)"
 	@echo "- osx, osx-python2/3, ios-armv7, ios-arm64, ios-sim (need Apple/OSX)"
@@ -122,6 +122,8 @@ clean:
 	make clean -C src
 	rm -f ${extras}/index.*
 	rm -rf ${npm}
+	rm -rf ${pwd}/build/asmjs
+	rm -rf ${pwd}/build/rnjs
 
 clean-src:
 	make clean -C src

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ test-exec := ${pwd}/src/zenroom-shared -c ${pwd}/test/decode-test.conf
 
 all:
 	@echo "Choose a target:"
-	@echo "- javascript-asmjs, javascript-npm, javascript-rn, javascript-demo (need EMSDK env)"
+	@echo "- javascript-asmjs, javascript-wasm, javascript-rn, javascript-demo (need EMSDK env)"
 	@echo "- linux, linux-lib, linux-clang, linux-debug"
 	@echo "- linux-python, linux-java        (language bindings)"
 	@echo "- osx, osx-python2/3, ios-armv7, ios-arm64, ios-sim (need Apple/OSX)"
@@ -121,9 +121,10 @@ clean:
 	rm -rf ${pwd}/lib/milagro-crypto-c/CMakeFiles
 	make clean -C src
 	rm -f ${extras}/index.*
-	rm -rf ${npm}
 	rm -rf ${pwd}/build/asmjs
+	rm -rf ${pwd}/build/wasm
 	rm -rf ${pwd}/build/rnjs
+	rm -rf ${pwd}/build/npm
 
 clean-src:
 	make clean -C src

--- a/build/config.mk
+++ b/build/config.mk
@@ -3,7 +3,6 @@
 pwd := $(shell pwd)
 mil := ${pwd}/build/milagro
 extras := ${pwd}/docs/demo
-npm := ${pwd}/build/npm
 
 # --------
 # defaults

--- a/build/dl-binaries.sh
+++ b/build/dl-binaries.sh
@@ -15,7 +15,7 @@ wget https://sdk.dyne.org:4443/view/decode/job/zenroom-python/lastSuccessfulBuil
 popd
 
 # javascript-demo
-push wasm
+push demo
 wget https://sdk.dyne.org:4443/view/decode/job/zenroom-demo/lastSuccessfulBuild/artifact/docs/demo/index.data
 wget https://sdk.dyne.org:4443/view/decode/job/zenroom-demo/lastSuccessfulBuild/artifact/docs/demo/index.html
 wget https://sdk.dyne.org:4443/view/decode/job/zenroom-demo/lastSuccessfulBuild/artifact/docs/demo/index.js
@@ -25,10 +25,15 @@ popd
 push reactnative
 wget https://sdk.dyne.org:4443/view/decode/job/zenroom-react/lastSuccessfulBuild/artifact/build/rnjs/zenroom.js
 popd
-# nodejs
-push nodejs
-wget https://sdk.dyne.org:4443/view/decode/job/zenroom-nodejs/lastSuccessfulBuild/artifact/src/zenroom.js
-wget https://sdk.dyne.org:4443/view/decode/job/zenroom-nodejs/lastSuccessfulBuild/artifact/src/zenroom.js.mem
+# asmjs
+push asmjs
+wget https://sdk.dyne.org:4443/view/decode/job/zenroom-asmjs/lastSuccessfulBuild/artifact/build/asmjs/zenroom.js
+wget https://sdk.dyne.org:4443/view/decode/job/zenroom-asmjs/lastSuccessfulBuild/artifact/build/asmjs/zenroom.js.mem
+popd
+# wasm
+push wasm
+wget https://sdk.dyne.org:4443/view/decode/job/zenroom-wasm/lastSuccessfulBuild/artifact/build/wasm/zenroom.js
+wget https://sdk.dyne.org:4443/view/decode/job/zenroom-wasm/lastSuccessfulBuild/artifact/build/wasm/zenroom.wasm
 popd
 
 # linux	

--- a/build/javascript.mk
+++ b/build/javascript.mk
@@ -28,7 +28,8 @@ javascript-wasm: ldflags += -s WASM=1 \
 	-s MODULARIZE=1 \
 	-s ALLOW_MEMORY_GROWTH=1 \
 	-s WARN_UNALIGNED=1 \
-	-s EXPORT_NAME="'ZR'"
+	-s EXPORT_NAME="'ZR'" \
+	--no-heap-copy
 javascript-wasm: apply-patches lua53 milagro embed-lua
 	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
 	make -C src js

--- a/build/javascript.mk
+++ b/build/javascript.mk
@@ -39,6 +39,7 @@ javascript-wasm: apply-patches lua53 milagro embed-lua
 
 javascript-rn: cflags += -DARCH_JS -D'ARCH=\"JS\"' -D MAX_STRING=128000
 javascript-rn: ldflags += -s WASM=0 \
+	-s ENVIRONMENT=\"'shell'\" \
 	-s MODULARIZE=1 \
 	-s LEGACY_VM_SUPPORT=1 \
 	-s ASSERTIONS=1 \
@@ -49,10 +50,6 @@ javascript-rn: apply-patches lua53 milagro embed-lua
 	sed -i 's/require("crypto")/require(".\/crypto")/g' src/zenroom.js
 	sed -i 's/require("[^\.]/console.log("/g' src/zenroom.js
 	sed -i 's/console.warn.bind/console.log.bind/g' src/zenroom.js
-	sed -i 's/;ENVIRONMENT_IS_SHELL=[^;]*;/;ENVIRONMENT_IS_SHELL=true;/g' src/zenroom.js
-	sed -i 's/;ENVIRONMENT_IS_NODE=[^;]*;/;ENVIRONMENT_IS_NODE=false;/g' src/zenroom.js
-	sed -i 's/;ENVIRONMENT_IS_WORKER=[^;]*;/;ENVIRONMENT_IS_WORKER=false;/g' src/zenroom.js
-	sed -i 's/;ENVIRONMENT_IS_WEB=[^;]*;/;ENVIRONMENT_IS_WEB=false;/g' src/zenroom.js
 	@mkdir -p build/rnjs
 	@cp -v src/zenroom.js 	  build/rnjs/
 

--- a/build/javascript.mk
+++ b/build/javascript.mk
@@ -1,7 +1,8 @@
 # TODO: improve flags according to
 # https://github.com/kripken/emscripten/blob/master/src/settings.js
-javascript-node: cflags += -DARCH_JS -D'ARCH=\"JS\"' -D MAX_STRING=128000 --memory-init-file 1
-javascript-node: ldflags += --memory-init-file 1 -s WASM=0
+javascript-node: cflags += -DARCH_JS -D'ARCH=\"JS\"' -D MAX_STRING=128000
+javascript-node: ldflags += -s WASM=0 \
+	--memory-init-file 1
 javascript-node: apply-patches lua53 milagro embed-lua
 	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
 	make -C src js
@@ -9,12 +10,17 @@ javascript-node: apply-patches lua53 milagro embed-lua
 	@cp -v src/zenroom.js 	  build/nodejs/
 	@cp -v src/zenroom.js.mem build/nodejs/
 
-javascript-rn: cflags += -DARCH_JS -D'ARCH=\"JS\"' --memory-init-file 0 -D MAX_STRING=128000
-javascript-rn: ldflags += -s WASM=0 --memory-init-file 0 -s MEM_INIT_METHOD=0 -s ASSERTIONS=1 -s NO_EXIT_RUNTIME=0 -s LEGACY_VM_SUPPORT=1 -s MODULARIZE=1
+javascript-rn: cflags += -DARCH_JS -D'ARCH=\"JS\"' -D MAX_STRING=128000
+javascript-rn: ldflags += -s WASM=0 \
+	-s MODULARIZE=1 \
+	-s LEGACY_VM_SUPPORT=1 \
+	-s MEM_INIT_METHOD=0 \
+	-s ASSERTIONS=1 \
+	-s EXIT_RUNTIME=1 \
+	--memory-init-file 0
 javascript-rn: apply-patches lua53 milagro embed-lua
 	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
 	make -C src js
-	@mkdir -p build/rnjs
 	sed -i 's/require("crypto")/require(".\/crypto")/g' src/zenroom.js
 	sed -i 's/require("[^\.]/console.log("/g' src/zenroom.js
 	sed -i 's/console.warn.bind/console.log.bind/g' src/zenroom.js
@@ -22,10 +28,14 @@ javascript-rn: apply-patches lua53 milagro embed-lua
 	sed -i 's/;ENVIRONMENT_IS_NODE=[^;]*;/;ENVIRONMENT_IS_NODE=false;/g' src/zenroom.js
 	sed -i 's/;ENVIRONMENT_IS_WORKER=[^;]*;/;ENVIRONMENT_IS_WORKER=false;/g' src/zenroom.js
 	sed -i 's/;ENVIRONMENT_IS_WEB=[^;]*;/;ENVIRONMENT_IS_WEB=false;/g' src/zenroom.js
+	@mkdir -p build/rnjs
 	@cp -v src/zenroom.js 	  build/rnjs/
 
 javascript-demo: cflags  += -DARCH_WASM -D'ARCH=\"WASM\"' -D MAX_STRING=128000
-javascript-demo: ldflags += -s WASM=1 -s ASSERTIONS=1 --shell-file ${extras}/shell_minimal.html -s NO_EXIT_RUNTIME=1
+javascript-demo: ldflags += -s WASM=1 \
+	-s ASSERTIONS=1 \
+	-s NO_EXIT_RUNTIME=1 \
+	--shell-file ${extras}/shell_minimal.html
 javascript-demo: apply-patches lua53 milagro embed-lua
 	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
 	make -C src js-demo
@@ -34,15 +44,16 @@ javascript-demo: apply-patches lua53 milagro embed-lua
 	@cp -v docs/demo/*.js build/demo/
 
 javascript-npm: cflags  += -DARCH_WASM -D'ARCH=\"WASM\"' -D MAX_STRING=128000
-javascript-npm: ldflags += -s INVOKE_RUN=0 \
-						   -s EXPORT_NAME="'ZR'" \
-						   -s MODULARIZE=1 \
-						   -s FILESYSTEM=1 \
-						   -s NODEJS_CATCH_EXIT=0 \
-						   -s ALLOW_MEMORY_GROWTH=1 \
-						   -s WARN_UNALIGNED=1 --memory-init-file 0 \
-						   -s EXIT_RUNTIME=1 \
-						   -s WASM=1
+javascript-npm: ldflags += -s WASM=1 \
+	-s INVOKE_RUN=0 \
+	-s EXPORT_NAME="'ZR'" \
+	-s MODULARIZE=1 \
+	-s FILESYSTEM=1 \
+	-s NODEJS_CATCH_EXIT=0 \
+	-s ALLOW_MEMORY_GROWTH=1 \
+	-s WARN_UNALIGNED=1 \
+	-s EXIT_RUNTIME=1 \
+	--memory-init-file 0
 javascript-npm: apply-patches lua53 milagro embed-lua
 	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
 	make -C src js
@@ -50,4 +61,3 @@ javascript-npm: apply-patches lua53 milagro embed-lua
 	@cp -v src/zenroom.js build/npm/
 	@cp -v src/zenroom.wasm build/npm/
 	@echo "module.exports = ZR();" >> build/npm/zenroom.js
-

--- a/build/javascript.mk
+++ b/build/javascript.mk
@@ -58,3 +58,21 @@ javascript-npm: javascript-wasm
 	@cp -v build/wasm/zenroom.js build/npm/
 	@cp -v build/wasm/zenroom.wasm build/npm/
 	@echo "module.exports = ZR();" >> build/npm/zenroom.js
+
+javascript-wasm-web: cflags  += -DARCH_WASM -D'ARCH=\"WASM\"' -D MAX_STRING=128000
+javascript-wasm-web: ldflags += -s WASM=1 \
+	-s ENVIRONMENT=\"'web'\" \
+	-s INVOKE_RUN=0 \
+	-s EXIT_RUNTIME=1 \
+	-s NODEJS_CATCH_EXIT=0 \
+	-s MODULARIZE=1 \
+	-s ALLOW_MEMORY_GROWTH=1 \
+	-s WARN_UNALIGNED=1 \
+	-s EXPORT_NAME="'ZR'" \
+	--no-heap-copy
+javascript-wasm-web: apply-patches lua53 milagro embed-lua
+	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
+	make -C src js
+	@mkdir -p build/wasm-web
+	@cp -v src/zenroom.js build/wasm-web/
+	@cp -v src/zenroom.wasm build/wasm-web/

--- a/build/javascript.mk
+++ b/build/javascript.mk
@@ -2,7 +2,7 @@
 # https://github.com/kripken/emscripten/blob/master/src/settings.js
 javascript-node: cflags += -DARCH_JS -D'ARCH=\"JS\"' -D MAX_STRING=128000
 javascript-node: ldflags += -s WASM=0 \
-	--memory-init-file 1
+	-s MEM_INIT_METHOD=1
 javascript-node: apply-patches lua53 milagro embed-lua
 	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
 	make -C src js
@@ -14,10 +14,8 @@ javascript-rn: cflags += -DARCH_JS -D'ARCH=\"JS\"' -D MAX_STRING=128000
 javascript-rn: ldflags += -s WASM=0 \
 	-s MODULARIZE=1 \
 	-s LEGACY_VM_SUPPORT=1 \
-	-s MEM_INIT_METHOD=0 \
 	-s ASSERTIONS=1 \
-	-s EXIT_RUNTIME=1 \
-	--memory-init-file 0
+	-s EXIT_RUNTIME=1
 javascript-rn: apply-patches lua53 milagro embed-lua
 	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
 	make -C src js
@@ -32,10 +30,7 @@ javascript-rn: apply-patches lua53 milagro embed-lua
 	@cp -v src/zenroom.js 	  build/rnjs/
 
 javascript-demo: cflags  += -DARCH_WASM -D'ARCH=\"WASM\"' -D MAX_STRING=128000
-javascript-demo: ldflags += -s WASM=1 \
-	-s ASSERTIONS=1 \
-	-s NO_EXIT_RUNTIME=1 \
-	--shell-file ${extras}/shell_minimal.html
+javascript-demo: ldflags += -s WASM=1 --shell-file ${extras}/shell_minimal.html
 javascript-demo: apply-patches lua53 milagro embed-lua
 	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
 	make -C src js-demo
@@ -46,14 +41,12 @@ javascript-demo: apply-patches lua53 milagro embed-lua
 javascript-npm: cflags  += -DARCH_WASM -D'ARCH=\"WASM\"' -D MAX_STRING=128000
 javascript-npm: ldflags += -s WASM=1 \
 	-s INVOKE_RUN=0 \
-	-s EXPORT_NAME="'ZR'" \
-	-s MODULARIZE=1 \
-	-s FILESYSTEM=1 \
+	-s EXIT_RUNTIME=1 \
 	-s NODEJS_CATCH_EXIT=0 \
+	-s MODULARIZE=1 \
 	-s ALLOW_MEMORY_GROWTH=1 \
 	-s WARN_UNALIGNED=1 \
-	-s EXIT_RUNTIME=1 \
-	--memory-init-file 0
+	-s EXPORT_NAME="'ZR'"
 javascript-npm: apply-patches lua53 milagro embed-lua
 	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
 	make -C src js

--- a/build/javascript.mk
+++ b/build/javascript.mk
@@ -1,14 +1,24 @@
 # TODO: improve flags according to
 # https://github.com/kripken/emscripten/blob/master/src/settings.js
-javascript-node: cflags += -DARCH_JS -D'ARCH=\"JS\"' -D MAX_STRING=128000
-javascript-node: ldflags += -s WASM=0 \
+
+javascript-demo: cflags  += -DARCH_WASM -D'ARCH=\"WASM\"' -D MAX_STRING=128000
+javascript-demo: ldflags += -s WASM=1 --shell-file ${extras}/shell_minimal.html
+javascript-demo: apply-patches lua53 milagro embed-lua
+	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
+	make -C src js-demo
+	@mkdir -p build/demo
+	@cp -v docs/demo/index.* build/demo/
+	@cp -v docs/demo/*.js build/demo/
+
+javascript-asmjs: cflags += -DARCH_JS -D'ARCH=\"JS\"' -D MAX_STRING=128000
+javascript-asmjs: ldflags += -s WASM=0 \
 	-s MEM_INIT_METHOD=1
-javascript-node: apply-patches lua53 milagro embed-lua
+javascript-asmjs: apply-patches lua53 milagro embed-lua
 	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
 	make -C src js
-	@mkdir -p build/nodejs
-	@cp -v src/zenroom.js 	  build/nodejs/
-	@cp -v src/zenroom.js.mem build/nodejs/
+	@mkdir -p build/asmjs
+	@cp -v src/zenroom.js 	  build/asmjs/
+	@cp -v src/zenroom.js.mem build/asmjs/
 
 javascript-rn: cflags += -DARCH_JS -D'ARCH=\"JS\"' -D MAX_STRING=128000
 javascript-rn: ldflags += -s WASM=0 \
@@ -28,15 +38,6 @@ javascript-rn: apply-patches lua53 milagro embed-lua
 	sed -i 's/;ENVIRONMENT_IS_WEB=[^;]*;/;ENVIRONMENT_IS_WEB=false;/g' src/zenroom.js
 	@mkdir -p build/rnjs
 	@cp -v src/zenroom.js 	  build/rnjs/
-
-javascript-demo: cflags  += -DARCH_WASM -D'ARCH=\"WASM\"' -D MAX_STRING=128000
-javascript-demo: ldflags += -s WASM=1 --shell-file ${extras}/shell_minimal.html
-javascript-demo: apply-patches lua53 milagro embed-lua
-	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
-	make -C src js-demo
-	@mkdir -p build/demo
-	@cp -v docs/demo/index.* build/demo/
-	@cp -v docs/demo/*.js build/demo/
 
 javascript-npm: cflags  += -DARCH_WASM -D'ARCH=\"WASM\"' -D MAX_STRING=128000
 javascript-npm: ldflags += -s WASM=1 \

--- a/build/javascript.mk
+++ b/build/javascript.mk
@@ -20,6 +20,22 @@ javascript-asmjs: apply-patches lua53 milagro embed-lua
 	@cp -v src/zenroom.js 	  build/asmjs/
 	@cp -v src/zenroom.js.mem build/asmjs/
 
+javascript-wasm: cflags  += -DARCH_WASM -D'ARCH=\"WASM\"' -D MAX_STRING=128000
+javascript-wasm: ldflags += -s WASM=1 \
+	-s INVOKE_RUN=0 \
+	-s EXIT_RUNTIME=1 \
+	-s NODEJS_CATCH_EXIT=0 \
+	-s MODULARIZE=1 \
+	-s ALLOW_MEMORY_GROWTH=1 \
+	-s WARN_UNALIGNED=1 \
+	-s EXPORT_NAME="'ZR'"
+javascript-wasm: apply-patches lua53 milagro embed-lua
+	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
+	make -C src js
+	@mkdir -p build/wasm
+	@cp -v src/zenroom.js build/wasm/
+	@cp -v src/zenroom.wasm build/wasm/
+
 javascript-rn: cflags += -DARCH_JS -D'ARCH=\"JS\"' -D MAX_STRING=128000
 javascript-rn: ldflags += -s WASM=0 \
 	-s MODULARIZE=1 \
@@ -39,19 +55,8 @@ javascript-rn: apply-patches lua53 milagro embed-lua
 	@mkdir -p build/rnjs
 	@cp -v src/zenroom.js 	  build/rnjs/
 
-javascript-npm: cflags  += -DARCH_WASM -D'ARCH=\"WASM\"' -D MAX_STRING=128000
-javascript-npm: ldflags += -s WASM=1 \
-	-s INVOKE_RUN=0 \
-	-s EXIT_RUNTIME=1 \
-	-s NODEJS_CATCH_EXIT=0 \
-	-s MODULARIZE=1 \
-	-s ALLOW_MEMORY_GROWTH=1 \
-	-s WARN_UNALIGNED=1 \
-	-s EXPORT_NAME="'ZR'"
-javascript-npm: apply-patches lua53 milagro embed-lua
-	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
-	make -C src js
+javascript-npm: javascript-wasm
 	@mkdir -p build/npm
-	@cp -v src/zenroom.js build/npm/
-	@cp -v src/zenroom.wasm build/npm/
+	@cp -v build/wasm/zenroom.js build/npm/
+	@cp -v build/wasm/zenroom.wasm build/npm/
 	@echo "module.exports = ZR();" >> build/npm/zenroom.js

--- a/build/zip-binaries.sh
+++ b/build/zip-binaries.sh
@@ -114,8 +114,12 @@ for t in $targets; do
 			prepdir $dir
 			# download
 			download zenroom-react build/rnjs/zenroom.js $dir/zenroom-react.js
-			download zenroom-nodejs src/zenroom.js       $dir/zenroom.js
-			download zenroom-nodejs src/zenroom.js.mem   $dir/zenroom.js.mem
+			mkdir -p $dir/wasm
+			download zenroom-wasm build/wasm/zenroom.js     $dir/wasm/zenroom.js
+			download zenroom-wasm build/wasm/zenroom.wasm   $dir/wasm/zenroom.wasm
+			mkdir -p $dir/asmjs
+			download zenroom-asmjs build/asmjs/zenroom.js       $dir/asmjs/zenroom.js
+			download zenroom-asmjs build/asmjs/zenroom.js.mem   $dir/asmjs/zenroom.js.mem
 			mkdir -p $dir/webassembly
 			download zenroom-demo docs/demo/index.data   $dir/webassembly/index.data
 			download zenroom-demo docs/demo/index.js     $dir/webassembly/index.js

--- a/src/Makefile
+++ b/src/Makefile
@@ -121,6 +121,7 @@ clean:
 	rm -f zenroom-shared
 	rm -f zenroom.js
 	rm -f zenroom.js.mem
+	rm -f zenroom.wasm
 	rm -f zenroom.html
 
 .c.o:


### PR DESCRIPTION
I think it makes more sense naming the javascript-* make rules after the binary format they emit, rather than after the environment for which they were created.
Emscripten by default emits code capable of running in Node, Browser, Shell, Web Worker, and this is also our case, so I replaced `-nodejs` with `-asmjs` (that was particularly misleading as recent Node versions could understand Wasm binaries too) and `-npm` with `-wasm`.

I also added a sample target for a browser-optimized Wasm binary (`emcc -S ENVIRONMENT='web'`) that's named after the output format first, and the specific environment after, so `javascript-wasm-web`, showing differences between output format and target environment.

