### PR TITLE
adds native java jni bindings

### DIFF
--- a/bindings/java/decode/zenroom/Zenroom.java
+++ b/bindings/java/decode/zenroom/Zenroom.java
@@ -1,0 +1,38 @@
+/*
+ * DECODE App – A mobile app to control your personal data
+ *
+ * Copyright (C) 2019 – DRIBIA Data Research S.L.
+ *
+ * DECODE App is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * DECODE App is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * email: info@dribia.com
+ */
+
+/**
+ * This class contains the JNI bindings for the native Zenroom library.
+ * It's package and method names are tied to it, be careful if you need changing them
+ */
+
+package decode.zenroom;
+
+
+
+public class Zenroom {
+
+    public native String zenroom(String script, String conf, String key, String data);
+
+    public String execute(String script, String conf, String key, String data) {
+        return zenroom(script, conf, key, data);
+    }
+}

--- a/bindings/java/testZenroom.java
+++ b/bindings/java/testZenroom.java
@@ -1,0 +1,41 @@
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+import decode.zenroom.Zenroom;
+
+public class testZenroom {
+
+    static {
+        try {
+            System.loadLibrary("zenroom");
+            // System.out.printf("Loaded zenroom native library\n");
+        } catch(Throwable exc) {
+            System.out.printf("Could not load zenroom native library: %s\n", exc.getMessage());
+        }
+    }
+
+    public static String conf = "debug=1";
+    public static String keys = "";
+    public static String data = "";
+
+    public static void main(String[] args) {
+	String script = "";
+        script = new String (readAllBytesJava7(args[0]));
+        String result = (new Zenroom()).execute(script, conf, keys, data);        
+  	System.out.printf("testZenroom result: %s", result);
+    }
+
+    private static String readAllBytesJava7(String filePath) {
+        String content = "";
+
+        try {
+            content = new String (Files.readAllBytes(Paths.get(filePath)));
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+
+        return content;
+    }
+
+}

--- a/build/build-java.sh
+++ b/build/build-java.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+
+if [ -z "${JAVA_HOME}" ]; then
+  echo "JAVA_HOME environment variable is not set. Setting JAVA_HOME to unlinked path from `which javac`"
+  export JAVA_HOME=${JAVA_HOME:=`dirname $(dirname $(readlink -f $(which javac)))`}
+fi
+
+echo "JAVA_HOME = ${JAVA_HOME}"
+
+LIB_SRC_PATH=${LIB_SRC_PATH:=${PWD}/src}
+LIB_DST_PATH=${LIB_DST_PATH:=${PWD}/build/target/java/jniLibs}
+LOCAL_ARCH=$(uname -m)
+
+build () {
+
+	echo "${0}: Building Java ${2} JNI lib ..."
+	make clean
+	make java-$1
+	mkdir -p ${LIB_DST_PATH}/${3}
+	cp -v ${LIB_SRC_PATH}/zenroom.so ${LIB_DST_PATH}/${3}/libzenroom.so
+}
+
+
+build "${LOCAL_ARCH}" "${LOCAL_ARCH}-linux-java" "${LOCAL_ARCH}"
+# build "arm" "arm-linux-androideabi" "armeabi-v7a"
+# build "aarch64" "aarch64-linux-android" "arm64-v8a"
+
+# BEGIN test
+ZEN_JAVA_LIB_PATH=${LIB_DST_PATH}/${LOCAL_ARCH}
+ZEN_JAVA_CLASSPATH="bindings/java"
+ZENCODE_SCRIPT="bindings/java/alice_keygen.zen"
+ZENCODE_TEST_CLASS="testZenroom"
+
+echo "${0}: Compiling test ${ZENCODE_TEST_CLASS}.java ..."
+# build test java source (hack)
+cd bindings/java/decode/zenroom/
+    javac Zenroom.java
+cd -
+
+cd bindings/java
+    javac ${ZENCODE_TEST_CLASS}.java
+cd -
+# create test data
+echo "${0}: Creating test zencode ${ZENCODE_SCRIPT}..."
+cat << EOF | tee ${ZENCODE_SCRIPT}
+rule check version 1.0.0
+Scenario 'simple': Create the keypair
+Given that I am known as 'Alice'
+When I create the keypair
+Then print my data
+EOF
+# run test
+Z="java -classpath ${ZEN_JAVA_CLASSPATH} -Djava.library.path=${ZEN_JAVA_LIB_PATH} ${ZENCODE_TEST_CLASS} ${ZENCODE_SCRIPT}"
+echo "${0}: Invoking java ${ZENCODE_TEST_CLASS}: ${Z} "
+${Z}
+# END test
+
+echo "Java JNI libs built under ${LIB_DST_PATH}"

--- a/build/config.mk
+++ b/build/config.mk
@@ -136,6 +136,14 @@ endif
 # -DCMAKE_ANDROID_NDK=${sysroot}
 #milagro_cmake_flags += -DCMAKE_ANDROID_STANDALONE_TOOLCHAIN=${ndk} -DCMAKE_SYSTEM_VERSION=26
 
+ifneq (,$(findstring java,$(MAKECMDGOALS)))
+jdk = ${JAVA_HOME}
+ldflags += -shared
+cflags += -fPIC ${cflags_protection} -DLIBRARY -D'ARCH=\"LINUX\"' -DARCH_LINUX
+cflags += -DLUA_USE_DLOPEN -I${jdk}/include -I${jdk}/include/linux
+system := Java
+endif
+
 ifneq (,$(findstring android,$(MAKECMDGOALS)))
 ndk = ${NDK_HOME}
 toolchain = ${ndk}/toolchains/llvm/prebuilt/linux-x86_64

--- a/build/linux.mk
+++ b/build/linux.mk
@@ -29,7 +29,7 @@ linux: apply-patches milagro lua53 embed-lua
 		make -C src linux
 		@cp -v src/zenroom build/zenroom
 
-android-arm android-x86 android-aarch64: apply-patches milagro lua53 embed-lua
+android-arm android-x86 android-aarch64 java-x86_64: apply-patches milagro lua53 embed-lua
 	CC=${gcc} CFLAGS="${cflags}" LDFLAGS="${ldflags}" LDADD="${ldadd}" \
 	LD="${ld}" RANLIB="${ranlib}" AR="${ar}" \
 		make -C src $@

--- a/src/Makefile
+++ b/src/Makefile
@@ -99,7 +99,7 @@ ios-lib: CFLAGS += -D LIBRARY
 ios-lib: ${SOURCES}
 	libtool -static -o zenroom-ios-${TARGET}.a ${SOURCES} $(shell find ../lib -name \*.a) ${LDADD}
 
-android-arm android-x86 android-aarch64: ${SOURCES} zenroom_jni.o
+android-arm android-x86 android-aarch64 java-x86_64 java-x86 java-arm java-aarch64: ${SOURCES} zenroom_jni.o
 	${CC} ${CFLAGS} ${SOURCES} zenroom_jni.o -o zenroom.so ${LDFLAGS} ${LDADD}
 
 arm: ${SOURCES}


### PR DESCRIPTION
@puria as per #https://github.com/DECODEproject/Zenroom/issues/93#issuecomment-613864834 copying existing make patterns from android, this PR adds the Zenroom.java under bindings/java and builds java jni libs with
```
JAVA_HOME=${JAVA_HOME:=`dirname $(dirname $(readlink -f $(which javac)))`} make java-x86_64
```
or
```
build/build-java.sh
```
the jni binders have so far only been tested for x86_64